### PR TITLE
Fix powershell integration to escape spaces

### DIFF
--- a/plugins/terminal/resources/shell-integrations/powershell/powershell-integration.ps1
+++ b/plugins/terminal/resources/shell-integrations/powershell/powershell-integration.ps1
@@ -17,7 +17,7 @@ Get-ChildItem env:_INTELLIJ_FORCE_PREPEND_* | ForEach-Object {
 
 $Script = Get-Item "env:JEDITERM_SOURCE" -ErrorAction SilentlyContinue
 if ($Script -ne $null) {
-  Invoke-Expression $Script.Value
+  & $Script.Value
   Remove-Item "env:JEDITERM_SOURCE"
 }
 


### PR DESCRIPTION
My username is "Crispin Stichart", and when launching PyCharm, I was seeing the following in the terminal:

> `C:/Users/Crispin : The term 'C:/Users/Crispin' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.`

I tracked it down to this line:

```
Invoke-Expression $Script.Value
```

Because `$Script.Value` was `C:/Users/Crispin Stichart/<path to project>/.venv/Scripts/activate.ps1`, and `Invoke-Expression` doesn't automatically escape spaces.

I know there are differences between `&` and `Invoke-Expression`, but the change seems to work perfectly on my end. `activate.ps1` is executed, and the environment variables set in that script take effect.